### PR TITLE
Add reserved keywords check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Support references in responses.
+- Fixed an issue where reserved keywords were being used as function/method arguments.
 
 ## [0.0.1] - 2017-10-15
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ ci: lint report build
 build:
 	go build .
 
+test:
+	go test -v ./...
+
 cover:
 	go test -cover ./...
 

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -162,8 +162,9 @@ func (f Field) equal(of Field) bool {
 // Client is a struct that holds the methods for communicating with an API
 // endpoint
 type Client struct {
-	Name    string
-	Comment string
+	Name        string
+	Comment     string
+	ContextName string
 
 	Methods []Method
 }
@@ -172,6 +173,7 @@ type Client struct {
 type Method struct {
 	Receiver struct {
 		ID   string
+		Arg  string
 		Type string
 	}
 
@@ -216,6 +218,7 @@ const (
 type Param struct {
 	ID         string
 	Orig       string // original name, ie for query params or headers
+	Arg        string // argument name, this is to avoid reserved keywords being used
 	Type       Type
 	Kind       Kind
 	Collection Collection

--- a/translator/format.go
+++ b/translator/format.go
@@ -1,6 +1,7 @@
 package translator
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
 )
@@ -60,6 +61,25 @@ func partsChan(words ...string) <-chan string {
 	}()
 
 	return c
+}
+
+var reserved = []string{
+	"break", "default", "func", "interface", "select", "case", "defer", "go",
+	"map", "struct", "chan", "else", "goto", "package", "switch", "const",
+	"fallthrough", "if", "range", "type", "continue", "for", "import",
+	"return", "var", "string", "bool", "int", "int8", "int16", "int32", "int64",
+	"uint", "uint8", "uint16", "uint32", "uint64", "float32", "float64",
+	"complex64", "complex128", "byte", "rune", "uintptr",
+}
+
+func formatReserved(s, c string) string {
+	for _, r := range reserved {
+		if s == r {
+			return fmt.Sprintf("%s%s", strings.ToLower(c), strings.Title(s))
+		}
+	}
+
+	return s
 }
 
 var acronyms = []string{

--- a/translator/translator_test.go
+++ b/translator/translator_test.go
@@ -42,3 +42,23 @@ func TestMethodMap(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatReserved(t *testing.T) {
+	tcs := []struct {
+		name    string
+		in      string
+		context string
+		out     string
+	}{
+		{"not reserved", "value", "testing", "value"},
+		{"reserved", "type", "testing", "testingType"},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if out := formatReserved(tc.in, tc.context); out != tc.out {
+				t.Error("got:", out, "expected:", tc.out)
+			}
+		})
+	}
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -75,7 +75,7 @@ func convertClientMethod(f *jen.File, m *pkg.Method, decls []pkg.TypeDecl) {
 
 	params := []jen.Code{jen.Id("ctx").Qual("context", "Context")}
 	for _, p := range m.Params {
-		v := jen.Id(p.ID).Do(writeType(p.Type))
+		v := jen.Id(p.Arg).Do(writeType(p.Type))
 
 		switch p.Kind {
 		case pkg.Path:
@@ -85,7 +85,7 @@ func convertClientMethod(f *jen.File, m *pkg.Method, decls []pkg.TypeDecl) {
 		case pkg.Header:
 			headerArgs = append(headerArgs, p)
 		case pkg.Body:
-			body = jen.Id(p.ID)
+			body = jen.Id(p.Arg)
 		case pkg.Opts:
 			for _, d := range decls {
 				if d.Name != typeName(p.Type) {
@@ -250,13 +250,13 @@ func setQueryArgs(g *jen.Group, errRet []jen.Code, args []pkg.Param) {
 			if t, ok := q.Type.(*pkg.IdentType); ok && t.Marshal {
 				g.List(jen.Id(q.ID+"Bytes"), jen.Err()).Op(":=").Id(q.ID).Dot("MarshalText").Call()
 				g.If(jen.Err().Op("!=").Nil()).Block(jen.Return(errRet...))
-				g.Id("q").Dot("Set").Call(jen.Lit(orig), jen.String().Params(jen.Id(q.ID+"Bytes")))
+				g.Id("q").Dot("Set").Call(jen.Lit(orig), jen.String().Params(jen.Id(q.Arg+"Bytes")))
 
 				if i != len(args)-1 {
 					g.Line()
 				}
 			} else {
-				g.Id("q").Dot("Set").Call(jen.Lit(orig), stringFor(q.Type, jen.Id(q.ID)))
+				g.Id("q").Dot("Set").Call(jen.Lit(orig), stringFor(q.Type, jen.Id(q.Arg)))
 			}
 		case pkg.Multi:
 			st := q.Type.(*pkg.SliceType)
@@ -352,12 +352,12 @@ func setHeaderArgs(g *jen.Group, errRet []jen.Code, args []pkg.Param) {
 		switch h.Collection {
 		case pkg.None:
 			if t, ok := h.Type.(*pkg.IdentType); ok && t.Marshal {
-				g.List(jen.Id(h.ID+"Bytes"), jen.Err()).Op(":=").Id(h.ID).Dot("MarshalText").Call()
+				g.List(jen.Id(h.Arg+"Bytes"), jen.Err()).Op(":=").Id(h.Arg).Dot("MarshalText").Call()
 				g.If(jen.Err().Op("!=").Nil()).Block(jen.Return(errRet...))
-				g.Id("req").Dot("Header").Dot("Set").Call(jen.Lit(orig), jen.String().Params(jen.Id(h.ID+"Bytes")))
+				g.Id("req").Dot("Header").Dot("Set").Call(jen.Lit(orig), jen.String().Params(jen.Id(h.Arg+"Bytes")))
 				g.Line()
 			} else {
-				g.Id("req").Dot("Header").Dot("Set").Call(jen.Lit(orig), stringFor(h.Type, jen.Id(h.ID)))
+				g.Id("req").Dot("Header").Dot("Set").Call(jen.Lit(orig), stringFor(h.Type, jen.Id(h.Arg)))
 				if i == len(args)-1 {
 					g.Line()
 				}

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -17,7 +17,7 @@ func TestSetQueryArgs(t *testing.T) {
 	}{
 		{"no args", nil, ""},
 		{"string arg",
-			[]pkg.Param{{ID: "arg", Type: &pkg.IdentType{}}},
+			[]pkg.Param{{ID: "arg", Arg: "arg", Type: &pkg.IdentType{}}},
 			`
 
 				q := make(url.Values)
@@ -25,15 +25,23 @@ func TestSetQueryArgs(t *testing.T) {
 			`,
 		},
 		{"different name",
-			[]pkg.Param{{ID: "arg", Orig: "arg_thing", Type: &pkg.IdentType{}}},
+			[]pkg.Param{{ID: "arg", Arg: "arg", Orig: "arg_thing", Type: &pkg.IdentType{}}},
 			`
 
 				q := make(url.Values)
 				q.Set("arg_thing", arg)
 			`,
 		},
+		{"different arg value",
+			[]pkg.Param{{ID: "arg", Arg: "different", Orig: "arg_thing", Type: &pkg.IdentType{}}},
+			`
+
+				q := make(url.Values)
+				q.Set("arg_thing", different)
+			`,
+		},
 		{"marshal",
-			[]pkg.Param{{ID: "arg", Type: &pkg.IdentType{Marshal: true}}},
+			[]pkg.Param{{ID: "arg", Arg: "arg", Type: &pkg.IdentType{Marshal: true}}},
 			`
 
 				q := make(url.Values)
@@ -46,9 +54,9 @@ func TestSetQueryArgs(t *testing.T) {
 		},
 		{"space after martial, not between regular",
 			[]pkg.Param{
-				{ID: "arg1", Type: &pkg.IdentType{Marshal: true}},
-				{ID: "arg2", Type: &pkg.IdentType{}},
-				{ID: "arg3", Type: &pkg.IdentType{}},
+				{ID: "arg1", Arg: "arg1", Type: &pkg.IdentType{Marshal: true}},
+				{ID: "arg2", Arg: "arg2", Type: &pkg.IdentType{}},
+				{ID: "arg3", Arg: "arg3", Type: &pkg.IdentType{}},
 			},
 			`
 
@@ -65,7 +73,7 @@ func TestSetQueryArgs(t *testing.T) {
 		},
 
 		{"multi collection string arg",
-			[]pkg.Param{{ID: "arg", Collection: pkg.Multi, Type: &pkg.SliceType{Type: &pkg.IdentType{}}}},
+			[]pkg.Param{{ID: "arg", Arg: "arg", Collection: pkg.Multi, Type: &pkg.SliceType{Type: &pkg.IdentType{}}}},
 			`
 
 				q := make(url.Values)
@@ -208,19 +216,19 @@ func TestSetHeaderArgs(t *testing.T) {
 	}{
 		{"no args", nil, ""},
 		{"string arg",
-			[]pkg.Param{{ID: "arg", Type: &pkg.IdentType{}}},
+			[]pkg.Param{{ID: "arg", Arg: "arg", Type: &pkg.IdentType{}}},
 			`req.Header.Set("arg", arg)
 
 			`,
 		},
 		{"different name",
-			[]pkg.Param{{ID: "arg", Orig: "arg_thing", Type: &pkg.IdentType{}}},
+			[]pkg.Param{{ID: "arg", Arg: "arg", Orig: "arg_thing", Type: &pkg.IdentType{}}},
 			`req.Header.Set("arg_thing", arg)
 
 			`,
 		},
 		{"marshal",
-			[]pkg.Param{{ID: "arg", Type: &pkg.IdentType{Marshal: true}}},
+			[]pkg.Param{{ID: "arg", Arg: "arg", Type: &pkg.IdentType{Marshal: true}}},
 			`argBytes, err := arg.MarshalText()
     			if err != nil {
     				return
@@ -231,9 +239,9 @@ func TestSetHeaderArgs(t *testing.T) {
 		},
 		{"space after martial, not between regular",
 			[]pkg.Param{
-				{ID: "arg1", Type: &pkg.IdentType{Marshal: true}},
-				{ID: "arg2", Type: &pkg.IdentType{}},
-				{ID: "arg3", Type: &pkg.IdentType{}},
+				{ID: "arg1", Arg: "arg1", Type: &pkg.IdentType{Marshal: true}},
+				{ID: "arg2", Arg: "arg2", Type: &pkg.IdentType{}},
+				{ID: "arg3", Arg: "arg3", Type: &pkg.IdentType{}},
 			},
 			`arg1Bytes, err := arg1.MarshalText()
     			if err != nil {


### PR DESCRIPTION
This adds another Param field, Arg. This allows us to specify a
different name for the parameters.

This is needed to avoid reserved keyword collisions. If we have, for
example, a field with the name `type`, this would have previously
assigned the arguments as `func List(..., type string, ...)`. This
causes the Go compiler to fail.

This patch will now prefix the client name to the keyword if it is
reserved: `func List(..., usersType string, ...)`.

closes https://github.com/jbowes/oag/issues/23