### PR TITLE
Add support for allOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Support non-string types in query and header parameters.
 - Support additionalProperties when no properties are defined, creating maps.
+- Support allOf. Referenced schemas are included as embedded structs. Inline
+  schemas have their fields included in the main struct directly.
 
 ### Fixed
 - Support references in responses.
-- Fixed an issue where reserved keywords were being used as function/method arguments.
+- Fixed an issue where reserved keywords were being used as function/method
+  arguments.
 - Fix support for reference parameters.
 
 ## [0.0.1] - 2017-10-15

--- a/mutator/mutator.go
+++ b/mutator/mutator.go
@@ -11,6 +11,7 @@ func Mutate(p *pkg.Package) *pkg.Package {
 		combineErrorsWithDefault,
 		inlinePrimitiveTypes,
 		inlineResponseStructs,
+		hoistEmbeddedStuctFields,
 		removeUnusedDecls,
 	}
 
@@ -113,6 +114,78 @@ func inlineResponseStructs(p *pkg.Package) *pkg.Package {
 				}
 
 				return t
+			})
+		}
+	}
+
+	return p
+}
+
+// hoistEmbeddedStuctFields finds any embedded structs from allOf schemas, and
+// hoists their fields into the embedding struct, when the embedded struct is not
+// referenced elsewhere.
+func hoistEmbeddedStuctFields(p *pkg.Package) *pkg.Package {
+	// XXX dedupe this code with inlineResponseStructs
+	ctxs := make(map[pkg.IdentType]struct {
+		c typeContext
+		n int
+	}, len(p.TypeDecls))
+
+	reachDecls(p, func(c typeContext, i *pkg.IdentType) bool {
+		v := ctxs[*i]
+		v.c |= c
+		v.n++
+		ctxs[*i] = v
+		return true
+	})
+
+	for _, d := range p.TypeDecls {
+		di := pkg.IdentType{Name: d.Name}
+		if pc, ok := ctxs[di]; ok {
+			d.Type = recurseType(d.Type, decl, func(t pkg.Type, c typeContext) pkg.Type {
+				st, ok := t.(*pkg.StructType)
+				if !ok {
+					return t
+				}
+
+				var nf []pkg.Field
+
+				for i := range st.Fields {
+					f := st.Fields[i]
+					if f.ID != "" {
+						nf = append(nf, f)
+						continue
+					}
+
+					var embedded *pkg.StructType
+					switch ft := f.Type.(type) {
+					case *pkg.IdentType:
+						if cc, ok := ctxs[*ft]; !ok || pc.n < cc.n {
+							nf = append(nf, f)
+							continue
+						}
+
+						resolved := resolve(p, ft)
+						if rst, ok := resolved.(*pkg.StructType); ok {
+							embedded = rst
+						} else {
+							nf = append(nf, f)
+							continue
+						}
+					case *pkg.StructType:
+						embedded = ft
+					default:
+						nf = append(nf, f)
+						continue
+					}
+
+					for j := range embedded.Fields {
+						nf = append(nf, embedded.Fields[j])
+					}
+				}
+
+				st.Fields = nf
+				return st
 			})
 		}
 	}

--- a/mutator/mutator.go
+++ b/mutator/mutator.go
@@ -62,7 +62,7 @@ func inlinePrimitiveTypes(p *pkg.Package) *pkg.Package {
 }
 
 func replaceType(p *pkg.Package, old, new pkg.Type) *pkg.Package {
-	return walkTypes(p, func(t pkg.Type) pkg.Type {
+	return walkTypes(p, func(t pkg.Type, _ typeContext) pkg.Type {
 		if old.Equal(t) {
 			return new
 		}
@@ -97,8 +97,12 @@ func inlineResponseStructs(p *pkg.Package) *pkg.Package {
 	for _, d := range p.TypeDecls {
 		di := pkg.IdentType{Name: d.Name}
 		if pc, ok := ctxs[di]; ok {
-			d.Type = recurseType(d.Type, func(t pkg.Type) pkg.Type {
+			d.Type = recurseType(d.Type, decl, func(t pkg.Type, c typeContext) pkg.Type {
 				if t == d.Type {
+					return t
+				}
+
+				if c&embeddedStruct > 0 {
 					return t
 				}
 
@@ -157,7 +161,7 @@ func removeUnusedDecls(p *pkg.Package) *pkg.Package {
 	return p
 }
 
-type typeContext byte
+type typeContext uint16
 
 const (
 	decl typeContext = 1 << iota
@@ -166,8 +170,11 @@ const (
 	methodReturn
 	methodError
 
+	structField
+	embeddedStruct
+
 	none typeContext = 0
-	any  typeContext = 0xFF
+	any  typeContext = 0xFFFF
 )
 
 type stackItem struct {
@@ -226,30 +233,30 @@ func reachDecls(p *pkg.Package, fn func(typeContext, *pkg.IdentType) bool) {
 	}
 }
 
-func walkTypes(p *pkg.Package, fn func(pkg.Type) pkg.Type) *pkg.Package {
+func walkTypes(p *pkg.Package, fn func(pkg.Type, typeContext) pkg.Type) *pkg.Package {
 	for i, d := range p.TypeDecls {
-		d.Type = recurseType(d.Type, fn)
+		d.Type = recurseType(d.Type, decl, fn)
 		p.TypeDecls[i] = d
 	}
 
-	for i, iter := range p.Iters {
-		iter.Return = recurseType(iter.Return, fn)
-		p.Iters[i] = iter
+	for i, itr := range p.Iters {
+		itr.Return = recurseType(itr.Return, iter, fn)
+		p.Iters[i] = itr
 	}
 
 	for _, c := range p.Clients {
 		for _, m := range c.Methods {
 			for i, param := range m.Params {
-				param.Type = recurseType(param.Type, fn)
+				param.Type = recurseType(param.Type, methodParam, fn)
 				m.Params[i] = param
 			}
 
 			for i, ret := range m.Return {
-				m.Return[i] = recurseType(ret, fn)
+				m.Return[i] = recurseType(ret, methodReturn, fn)
 			}
 
 			for k, e := range m.Errors {
-				m.Errors[k] = recurseType(e, fn)
+				m.Errors[k] = recurseType(e, methodError, fn)
 			}
 		}
 	}
@@ -257,25 +264,30 @@ func walkTypes(p *pkg.Package, fn func(pkg.Type) pkg.Type) *pkg.Package {
 	return p
 }
 
-func recurseType(typ pkg.Type, fn func(pkg.Type) pkg.Type) pkg.Type {
+func recurseType(typ pkg.Type, parentCtx typeContext, fn func(pkg.Type, typeContext) pkg.Type) pkg.Type {
 	switch t := typ.(type) {
 	case *pkg.StructType:
 		for i := range t.Fields {
-			t.Fields[i].Type = recurseType(t.Fields[i].Type, fn)
+			c := structField
+			if t.Fields[i].ID == "" {
+				c = embeddedStruct
+			}
+
+			t.Fields[i].Type = recurseType(t.Fields[i].Type, c, fn)
 		}
 	case *pkg.SliceType:
-		t.Type = recurseType(t.Type, fn)
+		t.Type = recurseType(t.Type, parentCtx, fn)
 	case *pkg.IterType:
-		t.Type = recurseType(t.Type, fn)
+		t.Type = recurseType(t.Type, parentCtx|iter, fn)
 	case *pkg.PointerType:
-		t.Type = recurseType(t.Type, fn)
+		t.Type = recurseType(t.Type, parentCtx, fn)
 	}
 
-	return fn(typ)
+	return fn(typ, parentCtx)
 }
 
 func eachIdent(typ pkg.Type, fn func(*pkg.IdentType)) {
-	recurseType(typ, func(t pkg.Type) pkg.Type {
+	recurseType(typ, any, func(t pkg.Type, _ typeContext) pkg.Type {
 		if i, ok := t.(*pkg.IdentType); ok {
 			fn(i)
 		}

--- a/mutator/mutator_test.go
+++ b/mutator/mutator_test.go
@@ -172,10 +172,10 @@ func TestInlineResponseStruct(t *testing.T) {
 		return pkg.Package{
 			TypeDecls: []pkg.TypeDecl{
 				{Name: "FieldThing", Type: &pkg.StructType{
-					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "string"}}},
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
 				}},
 				{Name: "StructThing", Type: &pkg.StructType{
-					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "FieldThing"}}},
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "FieldThing"}}},
 				}},
 			},
 			Clients: c,
@@ -186,12 +186,26 @@ func TestInlineResponseStruct(t *testing.T) {
 		return pkg.Package{
 			TypeDecls: []pkg.TypeDecl{
 				{Name: "FieldThing", Type: &pkg.StructType{
-					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "string"}}},
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
 				}},
 				{Name: "StructThing", Type: &pkg.StructType{
-					Fields: []pkg.Field{{Type: &pkg.StructType{
-						Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "string"}}},
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.StructType{
+						Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
 					}}},
+				}},
+			},
+			Clients: c,
+		}
+	}
+
+	embeddedStructPkg := func(c ...pkg.Client) pkg.Package {
+		return pkg.Package{
+			TypeDecls: []pkg.TypeDecl{
+				{Name: "FieldThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
+				}},
+				{Name: "StructThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "FieldThing"}}},
 				}},
 			},
 			Clients: c,
@@ -202,13 +216,13 @@ func TestInlineResponseStruct(t *testing.T) {
 		return pkg.Package{
 			TypeDecls: []pkg.TypeDecl{
 				{Name: "FieldThing", Type: &pkg.StructType{
-					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "string"}}},
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
 				}},
 				{Name: "StructThing", Type: &pkg.StructType{
-					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "FieldThing"}}},
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "FieldThing"}}},
 				}},
 				{Name: "OtherStructThing", Type: &pkg.StructType{
-					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "FieldThing"}}},
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "FieldThing"}}},
 				}},
 			},
 			Clients: c,
@@ -219,15 +233,15 @@ func TestInlineResponseStruct(t *testing.T) {
 		return pkg.Package{
 			TypeDecls: []pkg.TypeDecl{
 				{Name: "FieldThing", Type: &pkg.StructType{
-					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "string"}}},
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
 				}},
 				{Name: "StructThing", Type: &pkg.StructType{
-					Fields: []pkg.Field{{Type: &pkg.StructType{
-						Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "string"}}},
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.StructType{
+						Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
 					}}},
 				}},
 				{Name: "OtherStructThing", Type: &pkg.StructType{
-					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "FieldThing"}}},
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "FieldThing"}}},
 				}},
 			},
 			Clients: c,
@@ -247,6 +261,15 @@ func TestInlineResponseStruct(t *testing.T) {
 			}}}),
 			basePkg(pkg.Client{Methods: []pkg.Method{{
 				Params: []pkg.Param{{Type: &pkg.IdentType{Name: "StructThing"}}},
+			}}}),
+		},
+
+		{"not inlined if embedded struct",
+			embeddedStructPkg(pkg.Client{Methods: []pkg.Method{{
+				Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
+			}}}),
+			embeddedStructPkg(pkg.Client{Methods: []pkg.Method{{
+				Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
 			}}}),
 		},
 

--- a/mutator/mutator_test.go
+++ b/mutator/mutator_test.go
@@ -340,3 +340,173 @@ func TestInlineResponseStruct(t *testing.T) {
 		})
 	}
 }
+
+func TestHoistEmbeddedStructFields(t *testing.T) {
+	basePkg := func(c ...pkg.Client) pkg.Package {
+		return pkg.Package{
+			TypeDecls: []pkg.TypeDecl{
+				{Name: "FieldThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
+				}},
+				{Name: "StructThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "FieldThing"}}},
+				}},
+			},
+			Clients: c,
+		}
+	}
+
+	namedFieldPkg := func(c ...pkg.Client) pkg.Package {
+		return pkg.Package{
+			TypeDecls: []pkg.TypeDecl{
+				{Name: "FieldThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
+				}},
+				{Name: "StructThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "FieldThing"}}},
+				}},
+			},
+			Clients: c,
+		}
+	}
+
+	hoistedPkg := func(c ...pkg.Client) pkg.Package {
+		return pkg.Package{
+			TypeDecls: []pkg.TypeDecl{
+				{Name: "FieldThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
+				}},
+				{Name: "StructThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
+				}},
+			},
+			Clients: c,
+		}
+	}
+
+	doublePkg := func(c ...pkg.Client) pkg.Package {
+		return pkg.Package{
+			TypeDecls: []pkg.TypeDecl{
+				{Name: "FieldThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
+				}},
+				{Name: "StructThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "FieldThing"}}},
+				}},
+				{Name: "OtherStructThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "FieldThing"}}},
+				}},
+			},
+			Clients: c,
+		}
+	}
+
+	hoistedDoublePkg := func(c ...pkg.Client) pkg.Package {
+		return pkg.Package{
+			TypeDecls: []pkg.TypeDecl{
+				{Name: "FieldThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
+				}},
+				{Name: "StructThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{ID: "Field", Type: &pkg.IdentType{Name: "string"}}},
+				}},
+				{Name: "OtherStructThing", Type: &pkg.StructType{
+					Fields: []pkg.Field{{Type: &pkg.IdentType{Name: "FieldThing"}}},
+				}},
+			},
+			Clients: c,
+		}
+	}
+
+	tcs := []struct {
+		name string
+		in   pkg.Package
+		out  pkg.Package
+	}{
+		{"empty", pkg.Package{}, pkg.Package{}},
+
+		{"not hoisted if not embedded struct",
+			namedFieldPkg(pkg.Client{Methods: []pkg.Method{{
+				Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
+			}}}),
+			namedFieldPkg(pkg.Client{Methods: []pkg.Method{{
+				Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
+			}}}),
+		},
+
+		{"hoisted in params",
+			basePkg(pkg.Client{Methods: []pkg.Method{{
+				Params: []pkg.Param{{Type: &pkg.IdentType{Name: "StructThing"}}},
+			}}}),
+			hoistedPkg(pkg.Client{Methods: []pkg.Method{{
+				Params: []pkg.Param{{Type: &pkg.IdentType{Name: "StructThing"}}},
+			}}}),
+		},
+
+		{"hoisted in return",
+			basePkg(pkg.Client{Methods: []pkg.Method{{
+				Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
+			}}}),
+			hoistedPkg(pkg.Client{Methods: []pkg.Method{{
+				Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
+			}}}),
+		},
+
+		{"hoisted in error",
+			basePkg(pkg.Client{Methods: []pkg.Method{{
+				Errors: map[int]pkg.Type{-1: &pkg.IdentType{Name: "StructThing"}},
+			}}}),
+			hoistedPkg(pkg.Client{Methods: []pkg.Method{{
+				Errors: map[int]pkg.Type{-1: &pkg.IdentType{Name: "StructThing"}},
+			}}}),
+		},
+
+		{"hosited if used from many calls",
+			basePkg(
+				pkg.Client{Methods: []pkg.Method{{
+					Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
+				}}},
+				pkg.Client{Methods: []pkg.Method{{
+					Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
+				}}},
+			),
+			hoistedPkg(
+				pkg.Client{Methods: []pkg.Method{{
+					Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
+				}}},
+				pkg.Client{Methods: []pkg.Method{{
+					Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
+				}}},
+			),
+		},
+
+		{"not hoisted if used in many structs",
+			doublePkg(pkg.Client{Methods: []pkg.Method{{Return: []pkg.Type{
+				&pkg.IdentType{Name: "StructThing"},
+				&pkg.IdentType{Name: "OtherStructThing"},
+			}}}}),
+			doublePkg(pkg.Client{Methods: []pkg.Method{{Return: []pkg.Type{
+				&pkg.IdentType{Name: "StructThing"},
+				&pkg.IdentType{Name: "OtherStructThing"},
+			}}}}),
+		},
+
+		{"hoisted if used in many structs but only one reachable",
+			doublePkg(pkg.Client{Methods: []pkg.Method{{
+				Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
+			}}}),
+			hoistedDoublePkg(pkg.Client{Methods: []pkg.Method{{
+				Return: []pkg.Type{&pkg.IdentType{Name: "StructThing"}},
+			}}}),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			out := hoistEmbeddedStuctFields(&tc.in)
+			if !reflect.DeepEqual(*out, tc.out) {
+				t.Error("got:", out, "expected:", tc.out)
+			}
+		})
+	}
+}

--- a/translator/registry.go
+++ b/translator/registry.go
@@ -106,6 +106,31 @@ func (tr *typeRegistry) convertSchema(schema v2.Schema, td *pkg.TypeDecl, declAl
 		ret = &pkg.SliceType{Type: tr.convertSchema(s.Items, &pkg.TypeDecl{
 			Name: td.Name + "Items",
 		}, false)}
+	case *v2.AllOfSchema:
+		fields := make([]pkg.Field, len(s.AllOf))
+
+		for i := range s.AllOf {
+			sn := fmt.Sprintf("%sAllOf%d", td.Name, i)
+			field := pkg.Field{
+				Type: tr.convertSchema(s.AllOf[i], &pkg.TypeDecl{
+					Name:    sn,
+					Comment: fmt.Sprintf("%s is a data type for API communication.", sn),
+				}, false),
+			}
+
+			fields[i] = field
+		}
+
+		t := &pkg.StructType{
+			Fields: fields,
+		}
+
+		if td != nil {
+			td.Type = t
+			tr.types = append(tr.types, *td)
+		}
+
+		return &pkg.IdentType{Name: td.Name}
 	default:
 		// XXX handle this
 		panic("unknown type")

--- a/translator/registry_test.go
+++ b/translator/registry_test.go
@@ -89,6 +89,46 @@ func TestConvertSchema(t *testing.T) {
 				Value: &pkg.InterfaceType{},
 			}}},
 		},
+		{
+			"allOf empty",
+			&v2.AllOfSchema{
+				AllOf: []v2.Schema{},
+			},
+			&pkg.TypeDecl{Name: "Foo"},
+			&pkg.IdentType{Name: "Foo"},
+			[]pkg.TypeDecl{{Name: "Foo", Type: &pkg.StructType{Fields: []pkg.Field{}}}},
+		},
+		{
+			"allOf reference and struct",
+			&v2.AllOfSchema{
+				AllOf: []v2.Schema{
+					&v2.ReferenceSchema{Reference: "#/definitions/RefField"},
+					&v2.ObjectSchema{
+						Properties: &v2.SchemaMap{
+							{Name: "field", Schema: &v2.StringSchema{}},
+						},
+						Required: &[]string{"field"},
+					},
+				},
+			},
+			&pkg.TypeDecl{Name: "Foo"},
+			&pkg.IdentType{Name: "Foo"},
+			[]pkg.TypeDecl{
+				{
+					Name:    "FooAllOf1",
+					Comment: "FooAllOf1 is a data type for API communication.",
+					Type: &pkg.StructType{Fields: []pkg.Field{
+						{ID: "Field", Type: &pkg.IdentType{Name: "string"}, Orig: "field"},
+					}},
+				},
+				{
+					Name: "Foo", Type: &pkg.StructType{Fields: []pkg.Field{
+						{Type: &pkg.IdentType{Name: "RefField"}},
+						{Type: &pkg.IdentType{Name: "FooAllOf1"}},
+					}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
allOf schemas are treated as structs with embedded structs. For
non-refrence schemes within the allOf, mutation will hoist the fields to
the containing struct.

closes #11, #12