### PR TITLE
set up indirection for method parameters and return values

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,7 +54,10 @@ func generateClient() error {
 
 	code = mutator.Mutate(code)
 
-	o, _ := ioutil.ReadFile(cfg.Output)
+	o, err := ioutil.ReadFile(cfg.Output)
+	if err != nil {
+		return err
+	}
 
 	var buf bytes.Buffer
 	if err = writer.Write(&buf, code, &cfg.Boilerplate); err != nil {

--- a/translator/registry.go
+++ b/translator/registry.go
@@ -198,6 +198,12 @@ func (tr *typeRegistry) convertItems(i v2.Items) pkg.Type {
 	}
 }
 
+// indirect wraps a type in a pointer for use in parameters / return values,
+// if required.
+func (tr *typeRegistry) indirect(t pkg.Type) pkg.Type {
+	return &pkg.PointerType{Type: t}
+}
+
 type stringFormat map[string]string
 
 func (sf stringFormat) typeFor(fmt *string) pkg.Type {


### PR DESCRIPTION
This allows better control over if a pointer should be used or not,
allowing for interface parameters and returns.