### PR TITLE
Dereference optional variable if it's a SliceType

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -324,7 +324,7 @@ func setOptQueryArgs(g *jen.Group, errRet []jen.Code, qDefined bool, args []pkg.
 				})
 			case pkg.Multi:
 				st := typ.(*pkg.SliceType)
-				g.For(jen.List(jen.Id("_"), jen.Id("v")).Op(":=").Range().Id("opts").Dot(q.ID)).BlockFunc(func(g *jen.Group) {
+				g.For(jen.List(jen.Id("_"), jen.Id("v")).Op(":=").Range().Id("*opts").Dot(q.ID)).BlockFunc(func(g *jen.Group) {
 					if t, ok := st.Type.(*pkg.IdentType); ok && t.Marshal {
 						g.List(jen.Id("b"), jen.Err()).Op(":=").Id("v").Dot("MarshalText").Call()
 						g.If(jen.Err().Op("!=").Nil()).Block(jen.Return(errRet...))

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -201,7 +201,7 @@ func TestSetOptQueryArgs(t *testing.T) {
 				var q url.Values
 				if opts != nil {
 					q = make(url.Values)
-					for _, v := range opts.arg {
+					for _, v := range *opts.arg {
 						q.Add("arg", v)
 					}
 				}
@@ -215,7 +215,7 @@ func TestSetOptQueryArgs(t *testing.T) {
 				var q url.Values
 				if opts != nil {
 					q = make(url.Values)
-					for _, v := range opts.arg {
+					for _, v := range *opts.arg {
 						b, err := v.MarshalText()
 						if err != nil {
 							return


### PR DESCRIPTION
If a parameter type is `type: array`, and that value has `required: false`, dereference the pointer to the optional argument slice, so we can iterate over it to add parameters to and endpoint call.